### PR TITLE
Include cstddef

### DIFF
--- a/include/SpeedwireData2Packet.hpp
+++ b/include/SpeedwireData2Packet.hpp
@@ -1,6 +1,7 @@
 #ifndef __LIBSPEEDWIRE_SPEEDWIREDATA2PACKET_H__
 #define __LIBSPEEDWIRE_SPEEDWIREDATA2PACKET_H__
 
+#include <cstddef>
 #include <cstdint>
 #include <string>
 #include <SpeedwireByteEncoding.hpp>


### PR DESCRIPTION
With gcc 14.1 and cmake 3.29.3 I've had to include above in order to compile library. Since there is another cstd header included above (due to my limited knowledge), I suppose it is a harmless change to pass further c/cpp sanity checks.